### PR TITLE
Merge v5.1.0

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -9,7 +9,7 @@
 #			                    __/ |                             				    #
 #			                   |___/                              				    #
 #													    #
-## - 24/07/2017 -		   Asus Firewall Addition By Adamm v5.1.0				    #
+## - 03/08/2017 -		   Asus Firewall Addition By Adamm v5.1.0				    #
 ##				   https://github.com/Adamm00/IPSet_ASUS				    #
 #############################################################################################################
 
@@ -89,7 +89,11 @@ Kill_Lock () {
 
 Check_Settings () {
 		if [ ! -f /lib/modules/*/kernel/net/netfilter/ipset/ip_set_hash_ipmac.ko ]; then
-			logger -st Skynet "[ERROR] IPSet Extensions Not Enabled - Please Update To Newer Firmware"
+			logger -st Skynet "[ERROR] IPSet Extensions Not Enabled - Please Update To 380.68_alpha1 Or Newer Firmware"
+		else
+			sed -i 's/create Blacklist.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
+			sed -i 's/create BlockedRanges.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
+			sed -i 's/create Whitelist.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
 		fi
 
 		if ! grep -qF "Skynet" /jffs/scripts/firewall-start; then
@@ -644,9 +648,6 @@ case "$1" in
 			Unload_IPTables
 			Unload_DebugIPTables
 			Unload_IPSets
-			sed -i 's/create Blacklist.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
-			sed -i 's/create BlockedRanges.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
-			sed -i 's/create Whitelist.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
 			iptables -t raw -F
 			/usr/sbin/wget "$remoteurl" -qO "$0" && logger -st Skynet "[INFO] Skynet Sucessfully Updated - Restarting Firewall"
 			rm -rf /tmp/skynet.lock
@@ -952,8 +953,8 @@ case "$1" in
 		read -r mode4
 		case "$mode4" in
 			2)
-			echo
 			echo "USB Installation Selected"
+			echo
 			echo "Looking For Available Partitions..."
 			i=1
 			IFS="
@@ -996,18 +997,16 @@ case "$1" in
 			else
 				rm -rf "${device}/skynet/rwtest"
 			fi
-			mv "${location}/scripts/ipset.txt" "${device}/skynet/scripts/" >/dev/null 2>&1
-			mv "${location}/skynet.log" "${device}/skynet/" >/dev/null 2>&1
+			if [ -f "${location}/scripts/ipset.txt" ]; then mv "${location}/scripts/ipset.txt" "${device}/skynet/scripts/"; fi
+			if [ -f "${location}/skynet.log" ]; then mv "${location}/skynet.log" "${device}/skynet/"; fi
 			sed -i '\~ Skynet ~d' /jffs/scripts/firewall-start
 			echo "sh /jffs/scripts/firewall $set1 $set2 $set3 usb=${device} # Skynet Firewall Addition" | tr -s " " >> /jffs/scripts/firewall-start
 			;;
 			*)
 			echo "JFFS Installation Selected"
 			mkdir -p "/jffs/scripts"
-			if grep -q "usb=.*" /jffs/scripts/firewall-start; then
-				mv "${location}/scripts/ipset.txt" "/jffs/scripts/" >/dev/null 2>&1
-				mv "${location}/skynet.log" "/jffs/" >/dev/null 2>&1
-			fi
+			if [ -f "${location}/scripts/ipset.txt" ]; then mv "${location}/scripts/ipset.txt" "/jffs/scripts/"; fi
+			if [ -f "${location}/skynet.log" ]; then mv "${location}/skynet.log" "/jffs/"; fi
 			sed -i '\~ Skynet ~d' /jffs/scripts/firewall-start
 			echo "sh /jffs/scripts/firewall $set1 $set2 $set3 # Skynet Firewall Addition" | tr -s " " >> /jffs/scripts/firewall-start
 			;;

--- a/firewall.sh
+++ b/firewall.sh
@@ -627,7 +627,7 @@ case "$1" in
 	;;
 
 	update)
-		remoteurl="https://raw.githubusercontent.com/Adamm00/IPSet_ASUS/ipset-updated/firewall.sh"
+		remoteurl="https://raw.githubusercontent.com/Adamm00/IPSet_ASUS/master/firewall.sh"
 		/usr/sbin/wget "$remoteurl" -t2 -T2 -qO- | grep -qF "Adamm" || { logger -st Skynet "[ERROR] 404 Error Detected - Stopping Update" ; exit 1; }
 		localver="$(Filter_Version "$0")"
 		remotever="$(/usr/sbin/wget "$remoteurl" -qO- | Filter_Version)"

--- a/firewall.sh
+++ b/firewall.sh
@@ -338,10 +338,10 @@ case "$1" in
 			sed -i "/PT=${3} /d" "${location}/skynet.log"
 		elif [ "$2" = "country" ]; then
 			echo "Removing Previous Country Bans"
-			sed '/Country: /!d' /jffs/scripts/ipset.txt | sed 's/add/del/g' | ipset restore -! | ipset restore -!
+			sed '/Country: /!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -! | ipset restore -!
 		elif [ "$2" = "malware" ]; then
 			echo "Removing Previous Malware Bans"
-			sed '/Banmalware/!d' /jffs/scripts/ipset.txt | sed 's/add/del/g' | ipset restore -!
+			sed '/Banmalware/!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
 		elif [ "$2" = "autobans" ]; then
 			grep -F "NEW" "${location}/skynet.log" | grep -oE ' SRC=[0-9,\.]* ' | cut -c 6- | tr -d " " | while IFS= read -r ip; do
 				echo "Unbanning $ip"
@@ -404,7 +404,7 @@ case "$1" in
 				rm -rf "${location}/scripts/countrylist.txt"
 			fi
 			echo "Removing Previous Country Bans"
-			sed '/Country: /!d' /jffs/scripts/ipset.txt | sed 's/add/del/g' | ipset restore -!
+			sed '/Country: /!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
 			echo "Banning Known IP Ranges For $3"
 			echo "Downloading Lists"
 			for country in $3; do
@@ -436,7 +436,7 @@ case "$1" in
 			rm -rf "${location}/scripts/malwarelist.txt"
 		fi
 		echo "Removing Previous Malware Bans"
-		sed '/Banmalware/!d' /jffs/scripts/ipset.txt | sed 's/add/del/g' | ipset restore -!
+		sed '/BanMalware/!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
 		echo "Downloading Lists"
 		/usr/sbin/wget "$listurl" -qO /jffs/shared-Skynet-whitelist
 		/usr/sbin/wget -t2 -T2 -i /jffs/shared-Skynet-whitelist -qO- | sed -n "s/\\r//;/^$/d;/^[0-9,\\.,\\/]*$/p" | awk '!x[$0]++' | Filter_PrivateIP > /tmp/malwarelist.txt
@@ -454,7 +454,7 @@ case "$1" in
 			echo "Whitelisting Shared Domains"
 			grep -hvF "#" /jffs/shared-*-whitelist | sed 's~http[s]*://~~;s~/.*~~' | awk '!x[$0]++' | while IFS= read -r domain; do
 				for ip in $(Domain_Lookup "$domain" 2> /dev/null); do
-					ipset -q -A Whitelist "$ip" comment "SharedWhitelist $domain"
+					ipset -q -A Whitelist "$ip" comment "Shared-Whitelist: $domain"
 					ipset -q -D Blacklist "$ip"
 				done
 			done
@@ -591,9 +591,9 @@ case "$1" in
 		ipset restore -! -f "${location}/scripts/ipset.txt" || touch "${location}/scripts/ipset.txt"
 		Unban_PrivateIP
 		Purge_Logs
-		ipset -q create Whitelist nethash hashsize 65536 comment
-		ipset -q create Blacklist hash:ip --maxelem 500000 hashsize 4000000 comment
-		ipset -q create BlockedRanges hash:net hashsize 65536 comment
+		ipset -q create Whitelist nethash comment
+		ipset -q create Blacklist hash:ip --maxelem 500000 comment
+		ipset -q create BlockedRanges hash:net comment
 		ipset -q -A Whitelist 192.168.1.0/24 comment "LAN Subnet"
 		ipset -q -A Whitelist "$(nvram get wan0_ipaddr)"/32 comment "WAN IP Addr"
 		ipset -q -A Whitelist "$(nvram get lan_ipaddr)"/24 comment "LAN Subnet"

--- a/firewall.sh
+++ b/firewall.sh
@@ -583,7 +583,7 @@ case "$1" in
 
 	start)
 		Check_Lock
-		logger -st Skynet "[INFO] Startup Initiated... ($(grep -F "Skynet" /jffs/scripts/firewall-start | cut -c 4- | cut -d '#' -f1 | awk '{ $1=""; $2=""; print}') )"
+		logger -st Skynet "[INFO] Startup Initiated... ( $(echo "$@" | sed "s/start //g") )"
 		Unload_Cron
 		Check_Settings "$@"
 		cru a Skynet_save "0 * * * * sh /jffs/scripts/firewall save"
@@ -614,8 +614,10 @@ case "$1" in
 		logger -st Skynet "[INFO] Disabling Skynet..."
 		echo "Saving Changes"
 		{ ipset save Whitelist; ipset save Blacklist; ipset save BlockedRanges; } > "${location}/scripts/ipset.txt" 2>/dev/null
+		echo "Unloading IPTables Rules"
 		Unload_IPTables
 		Unload_DebugIPTables
+		echo "Unloading IPSets"
 		Unload_IPSets
 		Purge_Logs
 		Unload_Cron

--- a/firewall.sh
+++ b/firewall.sh
@@ -148,8 +148,8 @@ Unload_IPTables () {
 		iptables -D logdrop -p tcp --tcp-flags ALL ACK,PSH,FIN -j ACCEPT >/dev/null 2>&1
 		iptables -D logdrop -p icmp --icmp-type 3 -j ACCEPT >/dev/null 2>&1
 		iptables -D logdrop -p icmp --icmp-type 11 -j ACCEPT >/dev/null 2>&1
-		iptables -D SSHBFP -i -m recent --update --seconds 60 --hitcount 4 --name SSH --rsource -j SET --add-set Blacklist src >/dev/null 2>&1
-		iptables -D SSHBFP -i -m recent --update --seconds 60 --hitcount 4 --name SSH --rsource -j LOG --log-prefix "[BLOCKED - NEW BAN] " --log-tcp-sequence --log-tcp-options --log-ip-options >/dev/null 2>&1
+		iptables -D SSHBFP -m recent --update --seconds 60 --hitcount 4 --name SSH --rsource -j SET --add-set Blacklist src >/dev/null 2>&1
+		iptables -D SSHBFP -m recent --update --seconds 60 --hitcount 4 --name SSH --rsource -j LOG --log-prefix "[BLOCKED - NEW BAN] " --log-tcp-sequence --log-tcp-options --log-ip-options >/dev/null 2>&1
 }
 
 Load_IPTables () {

--- a/firewall.sh
+++ b/firewall.sh
@@ -772,9 +772,9 @@ case "$1" in
 			ipset test Blacklist "$4" && found2=true
 			ipset test BlockedRanges "$4" && found3=true
 			echo
-			if [ -n "$found1" ]; then echo "Whitelist Reason; $(grep -E Whitelist.*$4 ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
-			if [ -n "$found2" ]; then echo "Blacklist Reason; $(grep -E Blacklist.*$4 ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
-			if [ -n "$found3" ]; then echo "BlockedRanges Reason; $(grep -E BlockedRanges.*$4 ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
+			if [ -n "$found1" ]; then echo "Whitelist Reason; $(grep -E "Whitelist.*$4" ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
+			if [ -n "$found2" ]; then echo "Blacklist Reason; $(grep -E "Blacklist.*$4" ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
+			if [ -n "$found3" ]; then echo "BlockedRanges Reason; $(grep -E "BlockedRanges.*$(echo "$4" | cut -d '.' -f1-3)." ${location}/scripts/ipset.txt | awk '{$1=$2=$4=""; print $0}' | tr -s " ")"; fi
 			echo
 			echo "$4 First Tracked On $(grep -m1 -F "=$4 " ${location}/skynet.log | awk '{print $1" "$2" "$3}')"
 			echo "$4 Last Tracked On $(grep -F "=$4 " ${location}/skynet.log | tail -1 | awk '{print $1" "$2" "$3}')"

--- a/firewall.sh
+++ b/firewall.sh
@@ -338,10 +338,10 @@ case "$1" in
 			sed -i "/PT=${3} /d" "${location}/skynet.log"
 		elif [ "$2" = "country" ]; then
 			echo "Removing Previous Country Bans"
-			sed '/Country: /!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -! | ipset restore -!
+			sed '/Country: /!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -! | ipset restore -!
 		elif [ "$2" = "malware" ]; then
 			echo "Removing Previous Malware Bans"
-			sed '/Banmalware/!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
+			sed '/Banmalware/!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
 		elif [ "$2" = "autobans" ]; then
 			grep -F "NEW" "${location}/skynet.log" | grep -oE ' SRC=[0-9,\.]* ' | cut -c 6- | tr -d " " | while IFS= read -r ip; do
 				echo "Unbanning $ip"
@@ -404,7 +404,7 @@ case "$1" in
 				rm -rf "${location}/scripts/countrylist.txt"
 			fi
 			echo "Removing Previous Country Bans"
-			sed '/Country: /!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
+			sed '/Country: /!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
 			echo "Banning Known IP Ranges For $3"
 			echo "Downloading Lists"
 			for country in $3; do
@@ -436,7 +436,7 @@ case "$1" in
 			rm -rf "${location}/scripts/malwarelist.txt"
 		fi
 		echo "Removing Previous Malware Bans"
-		sed '/BanMalware/!d' /jffs/scripts/ipset.txt | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
+		sed '/BanMalware/!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
 		echo "Downloading Lists"
 		/usr/sbin/wget "$listurl" -qO /jffs/shared-Skynet-whitelist
 		/usr/sbin/wget -t2 -T2 -i /jffs/shared-Skynet-whitelist -qO- | sed -n "s/\\r//;/^$/d;/^[0-9,\\.,\\/]*$/p" | awk '!x[$0]++' | Filter_PrivateIP > /tmp/malwarelist.txt
@@ -645,9 +645,9 @@ case "$1" in
 			Unload_IPTables
 			Unload_DebugIPTables
 			Unload_IPSets
-			sed -i 's/create Blacklist.*[0-9]$/& comment/' /jffs/scripts/ipset.txt # Convert IPSets
-			sed -i 's/create BlockedRanges.*[0-9]$/& comment/' /jffs/scripts/ipset.txt # Convert IPSets
-			sed -i 's/create Whitelist.*[0-9]$/& comment/' /jffs/scripts/ipset.txt # Convert IPSets
+			sed -i 's/create Blacklist.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
+			sed -i 's/create BlockedRanges.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
+			sed -i 's/create Whitelist.*[0-9]$/& comment/' "${location}/scripts/ipset.txt" # Convert IPSets
 			iptables -t raw -F
 			/usr/sbin/wget "$remoteurl" -qO "$0" && logger -st Skynet "[INFO] Skynet Sucessfully Updated - Restarting Firewall"
 			rm -rf /tmp/skynet.lock

--- a/firewall.sh
+++ b/firewall.sh
@@ -9,7 +9,7 @@
 #			                    __/ |                             				    #
 #			                   |___/                              				    #
 #													    #
-## - 20/07/2017 -		   Asus Firewall Addition By Adamm v5.1.0				    #
+## - 21/07/2017 -		   Asus Firewall Addition By Adamm v5.1.0				    #
 ##				   https://github.com/Adamm00/IPSet_ASUS				    #
 #############################################################################################################
 
@@ -345,10 +345,10 @@ case "$1" in
 			sed -i "/PT=${3} /d" "${location}/skynet.log"
 		elif [ "$2" = "country" ]; then
 			echo "Removing Previous Country Bans"
-			sed '/Country: /!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -! | ipset restore -!
+			sed '/Country: /!d' "${location}/scripts/ipset.txt" | sed 's~ comment.*~~' | sed 's/add/del/g' | ipset restore -! | ipset restore -!
 		elif [ "$2" = "malware" ]; then
 			echo "Removing Previous Malware Bans"
-			sed '/Banmalware/!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
+			sed '/BanMalware/!d' "${location}/scripts/ipset.txt" | sed 's~ comment.*~~' | sed 's/add/del/g' | ipset restore -!
 		elif [ "$2" = "autobans" ]; then
 			grep -F "NEW" "${location}/skynet.log" | grep -oE ' SRC=[0-9,\.]* ' | cut -c 6- | tr -d " " | while IFS= read -r ip; do
 				echo "Unbanning $ip"
@@ -410,7 +410,7 @@ case "$1" in
 				rm -rf "${location}/scripts/countrylist.txt"
 			fi
 			echo "Removing Previous Country Bans"
-			sed '/Country: /!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
+			sed '/Country: /!d' "${location}/scripts/ipset.txt" | sed 's~ comment.*~~' | sed 's/add/del/g' | ipset restore -!
 			echo "Banning Known IP Ranges For $3"
 			echo "Downloading Lists"
 			for country in $3; do
@@ -441,14 +441,14 @@ case "$1" in
 			rm -rf "${location}/scripts/malwarelist.txt"
 		fi
 		echo "Removing Previous Malware Bans"
-		sed '/BanMalware/!d' "${location}/scripts/ipset.txt" | sed 's~[0-9] .*~~' | sed 's/add/del/g' | ipset restore -!
+		sed '/BanMalware/!d' "${location}/scripts/ipset.txt" | sed 's~ comment.*~~' | sed 's/add/del/g' | ipset restore -!
 		echo "Downloading Lists"
 		/usr/sbin/wget "$listurl" -qO /jffs/shared-Skynet-whitelist
 		/usr/sbin/wget -t2 -T2 -i /jffs/shared-Skynet-whitelist -qO- | sed -n "s/\\r//;/^$/d;/^[0-9,\\.,\\/]*$/p" | awk '!x[$0]++' | Filter_PrivateIP > /tmp/malwarelist.txt
 		echo "Filtering IPv4 Addresses"
-		grep -vF "/" /tmp/malwarelist.txt | awk '{print "add Blacklist " $1 " comment Banmalware"}' > "/tmp/malwarelist2.txt"
+		grep -vF "/" /tmp/malwarelist.txt | awk '{print "add Blacklist " $1 " comment BanMalware"}' > "/tmp/malwarelist2.txt"
 		echo "Filtering IPv4 Ranges"
-		grep -F "/" /tmp/malwarelist.txt | awk '{print "add BlockedRanges " $1 " comment Banmalware"}' >> "/tmp/malwarelist2.txt"
+		grep -F "/" /tmp/malwarelist.txt | awk '{print "add BlockedRanges " $1 " comment BanMalware"}' >> "/tmp/malwarelist2.txt"
 		echo "Applying Blacklists"
 		ipset restore -! -f "/tmp/malwarelist2.txt"
 		rm -rf "/tmp/malwarelist.txt" "/tmp/malwarelist2.txt"

--- a/firewall.sh
+++ b/firewall.sh
@@ -209,7 +209,7 @@ Is_IP () {
 }
 
 Domain_Lookup () {
-		nslookup "$1" | grep -woE '([0-9]{1,3}\.){3}[0-9]{1,3}' | awk 'NR>2'
+		nslookup "$(echo "$1" | sed 's~http[s]*://~~;s~/.*~~')" | grep -woE '([0-9]{1,3}\.){3}[0-9]{1,3}' | awk 'NR>2'
 }
 
 Filter_Version () {
@@ -495,7 +495,7 @@ case "$1" in
 		logger -st Skynet "[INFO] Adding $3 To Whitelist..."
 		for ip in $(Domain_Lookup "$3"); do
 			echo "Whitelisting $ip"
-			ipset -A Whitelist "$ip" comment "ManualWlist: $4"
+			ipset -A Whitelist "$ip" comment "ManualWlist: $3"
 			ipset -q -D Blacklist "$ip"
 			sed -i "\\~$ip ~d" "${location}/skynet.log"
 		done
@@ -567,7 +567,7 @@ case "$1" in
 		Unban_PrivateIP
 		Purge_Logs
 		Save_IPSets
-		sed -i '/USER admin pid .*firewall/d' /tmp/syslog.log
+		sed -i "/USER $(nvram get http_username) pid .*/jffs/scripts/firewall/d" /tmp/syslog.log
 		rm -rf /tmp/skynet.lock
 		;;
 

--- a/firewall.sh
+++ b/firewall.sh
@@ -417,7 +417,7 @@ case "$1" in
 				/usr/sbin/wget http://ipdeny.com/ipblocks/data/aggregated/"$country"-aggregated.zone -t2 -T2 -qO- >> /tmp/countrylist.txt
 			done
 			echo "Filtering IPv4 Ranges & Applying Blacklists"
-			grep -F "/" /tmp/countrylist.txt | sed -n "s/\\r//;/^$/d;/^[0-9,\\.,\\/]*$/s/^/add BlockedRanges /p" | sed "s/$/& comment Country: $country/" | ipset restore -!
+			grep -F "/" /tmp/countrylist.txt | sed -n "s/\\r//;/^$/d;/^[0-9,\\.,\\/]*$/s/^/add BlockedRanges /p" | sed "s/$/& comment \"Country: $3\"/" | ipset restore -!
 			rm -rf "/tmp/countrylist.txt"
 		else
 			echo "Command Not Recognised, Please Try Again"

--- a/firewall.sh
+++ b/firewall.sh
@@ -575,7 +575,7 @@ case "$1" in
 		Unban_PrivateIP
 		Purge_Logs
 		Save_IPSets
-		sed -i "/USER $(nvram get http_username) pid .*/jffs/scripts/firewall /d" /tmp/syslog.log
+		sed -i "\~USER $(nvram get http_username) pid .*/jffs/scripts/firewall ~d" /tmp/syslog.log
 		rm -rf /tmp/skynet.lock
 		;;
 
@@ -586,21 +586,23 @@ case "$1" in
 		Check_Settings "$@"
 		cru a Skynet_save "0 * * * * sh /jffs/scripts/firewall save"
 		modprobe xt_set
-		Unload_IPTables
-		Unload_DebugIPTables
-		Unload_IPSets
 		ipset restore -! -f "${location}/scripts/ipset.txt" || touch "${location}/scripts/ipset.txt"
 		if ! ipset -L -n Whitelist >/dev/null 2>&1; then ipset -q create Whitelist nethash comment; fi
 		if ! ipset -L -n Blacklist >/dev/null 2>&1; then ipset -q create Blacklist hash:ip --maxelem 500000 comment; fi
 		if ! ipset -L -n BlockedRanges >/dev/null 2>&1; then ipset -q create BlockedRanges hash:net comment; fi
 		if ! ipset -L -n Skynet >/dev/null 2>&1; then ipset -q create Skynet list:set; ipset -q -A Skynet Blacklist; ipset -q -A Skynet BlockedRanges; fi
-		Whitelist_Shared
 		ipset -q -A Skynet Blacklist
 		ipset -q -A Skynet BlockedRanges
-		Load_IPTables "$@"
-		Load_DebugIPTables "$@"
 		Unban_PrivateIP
 		Purge_Logs
+		Whitelist_Shared
+		while [ "$(($(date +%s) - stime))" -lt "20" ]; do
+			sleep 1
+		done
+		Unload_IPTables
+		Unload_DebugIPTables
+		Load_IPTables "$@"
+		Load_DebugIPTables "$@"
 		sed -i '/DROP IN=/d' /tmp/syslog.log
 		rm -rf /tmp/skynet.lock
 		;;

--- a/firewall.sh
+++ b/firewall.sh
@@ -771,9 +771,13 @@ case "$1" in
 			grep -F "PT=$4 " "${location}/skynet.log" | tail -"$counter"
 			exit 0
 		elif [ "$2" = "search" ] && [ "$3" = "ip" ] && [ -n "$4" ]; then
-			ipset test Whitelist "$4"
-			ipset test Blacklist "$4"
-			ipset test BlockedRanges "$4"
+			ipset test Whitelist "$4" && found1=true
+			ipset test Blacklist "$4" && found2=true
+			ipset test BlockedRanges "$4" && found3=true
+			echo
+			if [ -n "$found1" ]; then echo "Whitelist Reason; $(grep -E Whitelist.*$4 ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
+			if [ -n "$found2" ]; then echo "Blacklist Reason; $(grep -E Blacklist.*$4 ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
+			if [ -n "$found3" ]; then echo "BlockedRanges Reason; $(grep -E BlockedRanges.*$4 ${location}/scripts/ipset.txt | awk '{$1=$2=$3=$4=""; print $0}' | tr -s " ")"; fi
 			echo
 			echo "$4 First Tracked On $(grep -m1 -F "=$4 " ${location}/skynet.log | awk '{print $1" "$2" "$3}')"
 			echo "$4 Last Tracked On $(grep -F "=$4 " ${location}/skynet.log | tail -1 | awk '{print $1" "$2" "$3}')"

--- a/firewall.sh
+++ b/firewall.sh
@@ -440,9 +440,9 @@ case "$1" in
 		/usr/sbin/wget "$listurl" -qO /jffs/shared-Skynet-whitelist
 		/usr/sbin/wget -t2 -T2 -i /jffs/shared-Skynet-whitelist -qO- | sed -n "s/\\r//;/^$/d;/^[0-9,\\.,\\/]*$/p" | awk '!x[$0]++' | Filter_PrivateIP > /tmp/malwarelist.txt
 		echo "Filtering IPv4 Addresses"
-		grep -vF "/" /tmp/malwarelist.txt | awk '{print "add Blacklist " $1 " Banmalware"}' > "${location}/scripts/malwarelist.txt"
+		grep -vF "/" /tmp/malwarelist.txt | awk '{print "add Blacklist " $1 " comment Banmalware"}' > "${location}/scripts/malwarelist.txt"
 		echo "Filtering IPv4 Ranges"
-		grep -F "/" /tmp/malwarelist.txt | awk '{print "add BlockedRanges " $1 " Banmalware"}' >> "${location}/scripts/malwarelist.txt"
+		grep -F "/" /tmp/malwarelist.txt | awk '{print "add BlockedRanges " $1 " comment Banmalware"}' >> "${location}/scripts/malwarelist.txt"
 		echo "Applying Blacklists"
 		ipset restore -! -f "${location}/scripts/malwarelist.txt"
 		rm -rf /tmp/malwarelist.txt
@@ -538,9 +538,9 @@ case "$1" in
 			exit 2
 		fi
 		echo "Filtering IPv4 Addresses"
-		grep -woE '([0-9]{1,3}\.){3}[0-9]{1,3}' /tmp/iplist-unfiltered.txt | Filter_PrivateIP | awk '{print "add Blacklist " $1 "Imported"}' > /tmp/iplist-filtered.txt
+		grep -woE '([0-9]{1,3}\.){3}[0-9]{1,3}' /tmp/iplist-unfiltered.txt | Filter_PrivateIP | awk '{print "add Blacklist " $1 " comment Imported"}' > /tmp/iplist-filtered.txt
 		echo "Filtering IPv4 Ranges"
-		grep -woE '([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]{1,2}' /tmp/iplist-unfiltered.txt | Filter_PrivateIP | awk '{print "add BlockedRanges " $1 " Imported"}' >> /tmp/iplist-filtered.txt
+		grep -woE '([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]{1,2}' /tmp/iplist-unfiltered.txt | Filter_PrivateIP | awk '{print "add BlockedRanges " $1 " comment Imported"}' >> /tmp/iplist-filtered.txt
 		echo "Adding IPs To Blacklist"
 		ipset restore -! -f "/tmp/iplist-filtered.txt"
 		rm -rf /tmp/iplist-unfiltered.txt /tmp/iplist-filtered.txt


### PR DESCRIPTION
This will require MerlinWRT v380.68_alpha2 (or newer). Here are some of the changes;

Halve required IPTables rules and calculations
Optimized whitelisting shared domains
Optimize sed commands
More accurate boot arg printing
Show ban reason when using ( stats search ip xxx.xxx.xxx.xxx )
Better IPSet save management to prevent accidental loss of blacklists
More accurate entry removal
Try prevent cases where Skynet loads too fast and manipulates IPTables rules before they are flushed for a second time via the router (TL;DR less startup problems)

And finally the big change is Skynet has been rewritten so all entries now support comments. Whenever Skynet adds entries to either a Black or Whitelist it will have a comment associated with where it came from (for manual entries this is user defined, the example command list will be updated accordingly). No more wondering why something is on your Whitelist or Blacklist!

To update, please first install MerlinWRT v380.68_alpha2 (or newer). Then follow normal Skynet update procedure via using; ( sh /jffs/scripts/firewall update )


Note: If users wish to take full advantage of the new comment benefits, unfortunately there is no way to convert old entries. Skynet will try manually do this for banmalware and bancountry entries the next time the commands are run, unfortunately the rest will be left without comments. If you are in the position to and wish to take advantage of these features for all your entries, I suggest flushing your Whitelist and Blacklists after updating.