### PR TITLE
Fix PATH

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -21,7 +21,7 @@ if [ "$model" = "RT-AC87U" ] || [ "$model" = "RT-AC3200" ]; then
 		opkg install curl
 	fi
 else
-	export PATH=/sbin:/bin:/usr/sbin:/usr/bin$PATH
+	export PATH=/sbin:/bin:/usr/sbin:/usr/bin:$PATH
 fi
 printf '\033[?7l'
 clear


### PR DESCRIPTION
/opt/bin was getting changed to /usr/bin/opt/bin in PATH due to a missing colon.

Sorry about the EOF.