### PR TITLE
Fix problem when trying to use local banmalware list

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -3452,7 +3452,7 @@ case "$1" in
 				listurl="https://raw.githubusercontent.com/Adamm00/IPSet_ASUS/master/filter.list"
 			fi
 		fi
-		curl -sI "$listurl" | grep -qE "HTTP/1.[01] [23].." || { echo "[*] 404 Error Detected - Stopping Banmalware"; echo; exit 1; }
+		curl -fsI "$listurl" || { echo "[*] 404 Error Detected - Stopping Banmalware"; echo; exit 1; }
 		Display_Message "[i] Downloading filter.list"
 		if [ -n "$excludelists" ]; then
 			curl -fsL --retry 3 --connect-timeout 3 "$listurl" | dos2unix | grep -vE "($excludelists)" > /jffs/addons/shared-whitelists/shared-Skynet-whitelist && Display_Result

--- a/firewall.sh
+++ b/firewall.sh
@@ -3452,7 +3452,7 @@ case "$1" in
 				listurl="https://raw.githubusercontent.com/Adamm00/IPSet_ASUS/master/filter.list"
 			fi
 		fi
-		curl -fsI "$listurl" >/dev/null || { echo "[*] 404 Error Detected - Stopping Banmalware"; echo; exit 1; }
+		curl -fsSI "$listurl" >/dev/null || { echo; echo "[*] Stopping Banmalware"; echo; exit 1; }
 		Display_Message "[i] Downloading filter.list"
 		if [ -n "$excludelists" ]; then
 			curl -fsL --retry 3 --connect-timeout 3 "$listurl" | dos2unix | grep -vE "($excludelists)" > /jffs/addons/shared-whitelists/shared-Skynet-whitelist && Display_Result

--- a/firewall.sh
+++ b/firewall.sh
@@ -3452,7 +3452,7 @@ case "$1" in
 				listurl="https://raw.githubusercontent.com/Adamm00/IPSet_ASUS/master/filter.list"
 			fi
 		fi
-		curl -fsI "$listurl" || { echo "[*] 404 Error Detected - Stopping Banmalware"; echo; exit 1; }
+		curl -fsI "$listurl" >/dev/null || { echo "[*] 404 Error Detected - Stopping Banmalware"; echo; exit 1; }
 		Display_Message "[i] Downloading filter.list"
 		if [ -n "$excludelists" ]; then
 			curl -fsL --retry 3 --connect-timeout 3 "$listurl" | dos2unix | grep -vE "($excludelists)" > /jffs/addons/shared-whitelists/shared-Skynet-whitelist && Display_Result

--- a/firewall.sh
+++ b/firewall.sh
@@ -3452,7 +3452,7 @@ case "$1" in
 				listurl="https://raw.githubusercontent.com/Adamm00/IPSet_ASUS/master/filter.list"
 			fi
 		fi
-		curl -fsSI "$listurl" >/dev/null || { echo; echo "[*] Stopping Banmalware"; echo; exit 1; }
+		curl -fsSI "$listurl" >/dev/null || { echo "[*] Stopping Banmalware"; echo; exit 1; }
 		Display_Message "[i] Downloading filter.list"
 		if [ -n "$excludelists" ]; then
 			curl -fsL --retry 3 --connect-timeout 3 "$listurl" | dos2unix | grep -vE "($excludelists)" > /jffs/addons/shared-whitelists/shared-Skynet-whitelist && Display_Result


### PR DESCRIPTION
> See issue #82 for more details. This commit affects banmalware
> list setting.
> 
> Regex on a curl -I request was failing when using a protocol
> other than HTTP(S), including FILE protocol; FILE cURL requests
> would always be interpretted as a 404 error. This commit removes
> the regex error checking, and instead uses the cURL -f flag. No
> functionality should change, other than that local files can be
> used for banmalware.
> 
> Resolves: #82

This is a sister pull request for #82. 