### PR TITLE
Added M365 endpoints to the CDN List

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -882,6 +882,7 @@ Whitelist_CDN() {
 			curl -fsL --retry 3 --connect-timeout 3 https://www.cloudflare.com/ips-v4 | grep -E '([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}' | awk '{printf "add Skynet-Whitelist %s comment \"CDN-Whitelist: CloudFlare\"\n", $1 }'
 			curl -fsL --retry 3 --connect-timeout 3 https://ip-ranges.amazonaws.com/ip-ranges.json | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}' | awk '{printf "add Skynet-Whitelist %s comment \"CDN-Whitelist: Amazon\"\n", $1 }'
 			curl -fsL --retry 3 --connect-timeout 3 https://api.github.com/meta | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}' | awk '{printf "add Skynet-Whitelist %s comment \"CDN-Whitelist: Github\"\n", $1 }'
+			curl -fsL --retry 3 --connect-timeout 3 https://endpoints.office.com/endpoints/worldwide?clientrequestid=$(cat /proc/sys/kernel/random/uuid) | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}' | awk '{printf "add Skynet-Whitelist %s comment \"CDN-Whitelist: Microsoft365\"\n", $1 }'
 		} | awk '!x[$0]++' | ipset restore -!
 	fi
 }


### PR DESCRIPTION
I noticed that various ips needed for Office to function (mostly onedrive ones) kept winding up on zealous security lists (likely because someone downloaded malware hosted from onedrive). I am not 100% sure the CDN list is the perfect fit for this, but it seemed the best place.

I used the guidance [from microsoft](https://docs.microsoft.com/en-us/microsoft-365/enterprise/microsoft-365-ip-web-service?view=o365-worldwide) to determine the endpoint to query for their ips that should cover onedrive. The guid used for the "clientrequestid" is randomly generated each time.

I tested the inserted command works and produces the same output structure as the others in the CDN function, but I haven't tested the full script with it yet, largely because I am not entirely sure the best way to do this.