### PR TITLE
Restart dnsmasq during uninstall

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -5669,6 +5669,7 @@ case "$1" in
 					nvram commit
 					echo "[i] Deleting Skynet Files"
 					sed -i '\~# Skynet~d' /jffs/scripts/firewall-start /jffs/scripts/services-stop /jffs/scripts/service-event /jffs/configs/profile.add /jffs/configs/dnsmasq.conf.add
+					service restart_dnsmasq >/dev/null 2>&1
 					rm -rf "/jffs/addons/shared-whitelists/shared-Skynet-whitelist" "/jffs/addons/shared-whitelists/shared-Skynet2-whitelist" "${skynetloc}" "/jffs/scripts/firewall" "/opt/bin/firewall" "/tmp/skynet.lock" "/tmp/skynet"
 					if [ -f "/opt/etc/syslog-ng.d/skynet" ]; then
 						rm -rf "/opt/etc/syslog-ng.d/skynet"


### PR DESCRIPTION
After removing the ipset directives in dnsmasq.conf.add, a dnsmasq restart is required to stop dnsmasq from trying to add to an ipset that will no longer exist post-uninstall.