### PR TITLE
Don't read AiProtection DB if zero bytes

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -865,7 +865,7 @@ Unban_PrivateIP() {
 }
 
 Refresh_AiProtect() {
-	if [ "$banaiprotect" = "enabled" ] && [ -f /jffs/.sys/AiProtectionMonitor/AiProtectionMonitor.db ]; then
+	if [ "$banaiprotect" = "enabled" ] && [ -s /jffs/.sys/AiProtectionMonitor/AiProtectionMonitor.db ]; then
 		sed '\~add Skynet-Blacklist ~!d;\~BanAiProtect~!d;s~ comment.*~~;s~add~del~g' "$skynetipset" | ipset restore -!
 		sqlite3 /jffs/.sys/AiProtectionMonitor/AiProtectionMonitor.db "SELECT src FROM monitor;" | awk '!x[$0]++' | Filter_IP | Filter_PrivateIP | awk '{printf "add Skynet-Blacklist %s comment \"BanAiProtect\"\n", $1 }' | ipset restore -!
 		sqlite3 /jffs/.sys/AiProtectionMonitor/AiProtectionMonitor.db "SELECT dst FROM monitor;" | awk '!x[$0]++' | Filter_OutIP | grep -v ":" | while IFS= read -r "domain"; do


### PR DESCRIPTION
If banaiprotect is enabled, but AiProtection has never been enabled on a router, the sqlite DB file will exist but with zero bytes.

This causes error messages during an interactive banmalware refresh since the tables do not exist in the empty DB file.

Only query the tables if the DB file has a non-zero file size.