### PR TITLE
Fix swap cleanup during uninstall

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -5715,7 +5715,7 @@ case "$1" in
 							case "$removeswap" in
 								1)
 									echo "[i] Removing Skynet Generated SWAP File"
-									sed -i '\~ Skynet ~d' /jffs/scripts/post-mount /jffs/scripts/unmount
+									sed -i '\~# Skynet~d' /jffs/scripts/post-mount /jffs/scripts/unmount
 									sync; echo 3 > /proc/sys/vm/drop_caches
 									swapoff -a
 									rm -rf "$swaplocation"


### PR DESCRIPTION
sed pattern had a trailing space, probably from the times when "# Skynet Firewall Addition" was the standard comment. This prevented clean removal of the swapon/swapoff commands during uninstall.