### PR TITLE
Update filter lists

### DIFF
--- a/filter.list
+++ b/filter.list
@@ -6,4 +6,3 @@ https://iplists.firehol.org/files/et_compromised.ipset
 https://iplists.firehol.org/files/firehol_level2.netset
 https://iplists.firehol.org/files/firehol_level3.netset
 https://iplists.firehol.org/files/spamhaus_drop.netset
-https://iplists.firehol.org/files/urlvir.ipset

--- a/filter.list
+++ b/filter.list
@@ -5,5 +5,5 @@ https://iplists.firehol.org/files/et_block.netset
 https://iplists.firehol.org/files/et_compromised.ipset
 https://iplists.firehol.org/files/firehol_level2.netset
 https://iplists.firehol.org/files/firehol_level3.netset
-https://iplists.firehol.org/files/spamhaus_edrop.netset
+https://iplists.firehol.org/files/spamhaus_drop.netset
 https://iplists.firehol.org/files/urlvir.ipset


### PR DESCRIPTION
Spamhaus eDROP is now combined in DROP, and the firehol list hasn’t been updated since April. Switch to the DROP version to get the current updates.

urlvir is obsolete since 2019.