### PR TITLE
Prevent wrong client name in Get_LocalName()

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -1243,7 +1243,8 @@ Download_File() {
 }
 
 Get_LocalName() {
-	localname="$(nvram get custom_clientlist | grep -ioE "<.*>$macaddr" | sed -E 's/.*<([^>]+)>[^<]*$/\1/; s/[^a-zA-Z0-9.-]//g')"
+	localname=""
+	if [ -n "$macaddr" ]; then localname="$(nvram get custom_clientlist | grep -ioE "<.*>$macaddr" | sed -E 's/.*<([^>]+)>[^<]*$/\1/; s/[^a-zA-Z0-9.-]//g')"; fi
 	if [ -z "$localname" ]; then localname="$(grep -F "$ipaddr " /var/lib/misc/dnsmasq.leases | awk '{print $4}')"; fi
 	if [ -z "$localname" ] || [ "$localname" = "*" ]; then
 		if [ -n "$macaddr" ]; then


### PR DESCRIPTION
If a client IP is not online and present in `ip neigh` at the time of stats generation, the `macaddr` variable will be empty and the `Get_LocalName()` function will return the last client name from nvram variable `custom_clientlist`, instead of skipping to the DHCP lease file.