### PR TITLE
webui: Remove Tomato js references

### DIFF
--- a/webui/skynet.asp
+++ b/webui/skynet.asp
@@ -98,8 +98,6 @@
     <script language="JavaScript" type="text/javascript" src="/popup.js"></script>
     <script language="JavaScript" type="text/javascript" src="/help.js"></script>
     <script language="JavaScript" type="text/javascript" src="/detect.js"></script>
-    <script language="JavaScript" type="text/javascript" src="/tmhist.js"></script>
-    <script language="JavaScript" type="text/javascript" src="/tmmenu.js"></script>
     <script language="JavaScript" type="text/javascript" src="/validator.js"></script>
     <script>
         var ChartInPortHits;
@@ -197,7 +195,7 @@
                             return data.labels[tooltipItem[0].index];
                         },
                         label: function(tooltipItem, data) {
-                            return comma(data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]);
+                            return parseInt(data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index]).toLocaleString();
                         }
                     },
                     mode: 'point',


### PR DESCRIPTION
This is untested. Please test before merging.

This addresses browser errors due to the upstream Merlin removal of tmmenu.js which provided the comma() function used in the webUI. This change should now present the tooltip in the user's local number format instead of forcing the comma thousands separator.

Reference: https://www.snbforums.com/threads/skynet-v8-router-firewall-security-enhancements.96167/page-13#post-982201