### PR TITLE
Adjust Skynet-Blacklist maxelem based on architecture

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -5059,10 +5059,22 @@ case "$1" in
 		if ! Check_Connection 10 5; then echo; exit 1; fi
 		Load_Cron "save"
 		modprobe xt_set
+		ROUTER_ARCH="$(uname -m)"
+		case "$ROUTER_ARCH" in
+			aarch64|arm64)
+				BLK_VALUE="32"
+			;;
+			armv7l)
+				BLK_VALUE="16"
+			;;
+			*)
+				BLK_VALUE="16"
+			;;
+		esac
 		if [ -f "$skynetipset" ]; then ipset restore -! -f "$skynetipset"; else Log info -s "Setting Up Skynet"; touch "$skynetipset"; fi
 		if ! ipset -L -n Skynet-Whitelist >/dev/null 2>&1; then ipset -q create Skynet-Whitelist hash:net hashsize 64 maxelem "$((65536 * 6))" comment; fi
 		if ! ipset -L -n Skynet-WhitelistDomains >/dev/null 2>&1; then ipset -q create Skynet-WhitelistDomains hash:ip hashsize 64 maxelem "$((65536 * 8))" comment timeout 86400; fi
-		if ! ipset -L -n Skynet-Blacklist >/dev/null 2>&1; then ipset -q create Skynet-Blacklist hash:ip hashsize 64 maxelem "$((65536 * 16))" comment; fi
+		if ! ipset -L -n Skynet-Blacklist >/dev/null 2>&1; then ipset -q create Skynet-Blacklist hash:ip hashsize 64 maxelem "$((65536 * BLK_VALUE))" comment; fi
 		if ! ipset -L -n Skynet-BlockedRanges >/dev/null 2>&1; then ipset -q create Skynet-BlockedRanges hash:net hashsize 64 maxelem "$((65536 * 6))" comment; fi
 		if ! ipset -L -n Skynet-Master >/dev/null 2>&1; then ipset -q create Skynet-Master list:set; ipset -q -A Skynet-Master Skynet-Blacklist; ipset -q -A Skynet-Master Skynet-BlockedRanges; fi
 		if ! ipset -L -n Skynet-MasterWL >/dev/null 2>&1; then ipset -q create Skynet-MasterWL list:set; ipset -q -A Skynet-MasterWL Skynet-Whitelist; ipset -q -A Skynet-MasterWL Skynet-WhitelistDomains; fi


### PR DESCRIPTION
Adjust Skynet-Blacklist maxelem based on architecture

I use a lot of blacklist entries so had to increase the size. 
```
ROUTER_ARCH="$(uname -m)"
case "$ROUTER_ARCH" in
	aarch64|arm64)
		BLK_VALUE="32"
		;;
	armv7l)
		BLK_VALUE="16"
		;;
	*)
		BLK_VALUE="16"
		;;
esac

if ! ipset -L -n Skynet-Blacklist >/dev/null 2>&1; then ipset -q create Skynet-Blacklist hash:ip hashsize 64 maxelem "$((65536 * BLK_VALUE))" comment; fi
```
