### PR TITLE
fix Settings menu invalid option content

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -3848,7 +3848,7 @@ Load_Menu() {
 							break
 						;;
 						*)
-							Invalid_Option "$menu"
+							Invalid_Option "$menu2"
 						;;
 					esac
 				done


### PR DESCRIPTION
Currently shows the main menu selection instead of the Settings menu selection when throwing the error, due to wrong variable name.