### PR TITLE
Reduce risk of lock file corruption

### DIFF
--- a/firewall.sh
+++ b/firewall.sh
@@ -111,7 +111,7 @@ Check_Lock() {
 
 	# We now hold the lock — record this invocation
 	: > "$LOCK_FILE"
-	echo "$0 $*|$$|$(date +%s)" >&9
+	echo "$0 $*|$$|$(date +%s)" > "$LOCK_FILE"
 }
 
 Release_Lock() {


### PR DESCRIPTION
Some users encounter the "metadata invalid" condition in Check_Lock(). This occurs when the FD 9 is already locked but doesn't contain valid metadata written by previous Check_Lock() invocations. It's theoretically possible that the data is populated but is prepended with unprintable characters due to the writing to the FD 9 instead of $LOCK_FILE, most likely in re-entrant scenarios.
```
$ exec 9<>/tmp/skynet.lock
$ : >/tmp/skynet.lock
$ echo "/jffs/scripts/firewall banmalware|14305|$(date +%s)" >&9 
$ hexdump -C /tmp/skynet.lock
00000000  2f 6a 66 66 73 2f 73 63  72 69 70 74 73 2f 66 69  |/jffs/scripts/fi| 
00000010  72 65 77 61 6c 6c 20 62  61 6e 6d 61 6c 77 61 72  |rewall banmalwar| 
00000020  65 7c 31 34 33 30 35 7c  31 37 38 31 32 32 37 37  |e|14305|17812277|
00000030  37 31 0a                                          |71.|
00000033
$ : >/tmp/skynet.lock
$ echo "/jffs/scripts/firewall save|14305|$(date +%s)" >&9
$ hexdump -C /tmp/skynet.lock
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000030  00 00 00 2f 6a 66 66 73  2f 73 63 72 69 70 74 73  |.../jffs/scripts|
00000040  2f 66 69 72 65 77 61 6c  6c 20 73 61 76 65 7c 31  |/firewall save|1|
00000050  34 33 30 35 7c 31 37 38  31 32 32 37 38 32 34 0a  |4305|1781227824.|
00000060
```
Avoid this possibility completely by writing to the filename, not the file descriptor.
```
$ : >/tmp/skynet.lock
$ echo "/jffs/scripts/firewall debug genstats|14305|$(date +%s)" > /tmp/skynet.lock 
$ hexdump -C /tmp/skynet.lock
00000000  2f 6a 66 66 73 2f 73 63  72 69 70 74 73 2f 66 69  |/jffs/scripts/fi| 
00000010  72 65 77 61 6c 6c 20 64  65 62 75 67 20 67 65 6e  |rewall debug gen| 
00000020  73 74 61 74 73 7c 31 34  33 30 35 7c 31 37 38 31  |stats|14305|1781|
00000030  32 32 37 39 35 33 0a                              |227953.|
00000037
```